### PR TITLE
Add license information

### DIFF
--- a/src/main/java/io/swagger/swaggerhub/v2/DebugLogger.java
+++ b/src/main/java/io/swagger/swaggerhub/v2/DebugLogger.java
@@ -1,3 +1,17 @@
+/* Copyright 2025 Ludy87
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.swagger.swaggerhub.v2;
 
 import java.io.FileWriter;

--- a/src/main/java/io/swagger/swaggerhub/v2/tasks/SetDefaultVersion.java
+++ b/src/main/java/io/swagger/swaggerhub/v2/tasks/SetDefaultVersion.java
@@ -1,3 +1,17 @@
+/* Copyright 2025 Ludy87
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.swagger.swaggerhub.v2.tasks;
 
 import org.gradle.api.DefaultTask;

--- a/src/test/java/io/swagger/swaggerhub/v2/gradle/SwaggerHubSetDefaultVersionTest.java
+++ b/src/test/java/io/swagger/swaggerhub/v2/gradle/SwaggerHubSetDefaultVersionTest.java
@@ -1,3 +1,17 @@
+/* Copyright 2025 Ludy87
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.swagger.swaggerhub.v2.gradle;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-#Sat Mar 15 21:46:00 CET 2025
-version=2.0.83
+#Sun Mar 16 18:14:00 CET 2025
+version=2.0.84


### PR DESCRIPTION
Add license information to DebugLogger, SetDefaultVersion, and SwaggerHubSetDefaultVersionTest; update the version to 2.0.84