### PR TITLE
Disable caching for SwaggerHub network tasks and set UploadTask path sensitivity

### DIFF
--- a/src/main/java/io/github/ludy87/swagger/swaggerhub/v2/tasks/DownloadTask.java
+++ b/src/main/java/io/github/ludy87/swagger/swaggerhub/v2/tasks/DownloadTask.java
@@ -44,6 +44,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import org.slf4j.Logger;
 
 import io.github.ludy87.swagger.swaggerhub.v2.client.SwaggerHubClient;
@@ -55,6 +56,8 @@ import lombok.Setter;
 /** Downloads API definitions from SwaggerHub. */
 @Getter
 @Setter
+@DisableCachingByDefault(
+        because = "Task communicates with SwaggerHub and has network side effects.")
 public class DownloadTask extends DefaultTask {
     /** Logger instance for the task. */
     private static final Logger LOGGER = Logging.getLogger(DownloadTask.class);

--- a/src/main/java/io/github/ludy87/swagger/swaggerhub/v2/tasks/SetDefaultVersion.java
+++ b/src/main/java/io/github/ludy87/swagger/swaggerhub/v2/tasks/SetDefaultVersion.java
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import org.slf4j.Logger;
 
 import io.github.ludy87.swagger.swaggerhub.v2.client.SwaggerHubClient;
@@ -35,6 +36,8 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@DisableCachingByDefault(
+        because = "Task communicates with SwaggerHub and has network side effects.")
 public class SetDefaultVersion extends DefaultTask {
     /** Logger instance for the task. */
     private static final Logger LOGGER = Logging.getLogger(SetDefaultVersion.class);

--- a/src/main/java/io/github/ludy87/swagger/swaggerhub/v2/tasks/UploadTask.java
+++ b/src/main/java/io/github/ludy87/swagger/swaggerhub/v2/tasks/UploadTask.java
@@ -43,7 +43,10 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import org.slf4j.Logger;
 
 import io.github.ludy87.swagger.swaggerhub.v2.client.SwaggerHubClient;
@@ -55,6 +58,8 @@ import lombok.Setter;
 /** Uploads API definition to SwaggerHub. */
 @Getter
 @Setter
+@DisableCachingByDefault(
+        because = "Task communicates with SwaggerHub and has network side effects.")
 public class UploadTask extends DefaultTask {
     /** Logger instance for the task. */
     private static final Logger LOGGER = Logging.getLogger(UploadTask.class);
@@ -75,7 +80,9 @@ public class UploadTask extends DefaultTask {
     @Input private String token;
 
     /** Path to the API definition file. */
-    @InputFile private String inputFile;
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    private String inputFile;
 
     /** Flag indicating whether the API is private. */
     @Input private Boolean isPrivate = false;


### PR DESCRIPTION
### Motivation
- Prevent Gradle from caching tasks that communicate with SwaggerHub because they have network side effects.
- Make the `UploadTask` input file sensitivity explicit so Gradle's up-to-date checks treat the file path correctly.

### Description
- Added `@DisableCachingByDefault(because = "Task communicates with SwaggerHub and has network side effects.")` to `DownloadTask`, `UploadTask`, and `SetDefaultVersion`.
- Added `@PathSensitive(PathSensitivity.RELATIVE)` to the `@InputFile` `inputFile` property in `UploadTask`.
- Introduced imports for `org.gradle.work.DisableCachingByDefault`, `org.gradle.api.tasks.PathSensitive`, and `org.gradle.api.tasks.PathSensitivity` where required.
- Minor file header update in `SetDefaultVersion`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c74ccd6c8325af34cd38c8df623c)