### PR TITLE
ci: auto-merge Dependabot PRs & harden build workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 500
     rebase-strategy: "auto"
+    groups:
+      gradle-production-dependencies:
+        dependency-type: "production"
+      gradle-development-dependencies:
+        dependency-type: "development"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -18,8 +23,16 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 500
     rebase-strategy: "auto"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: daily
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,49 @@
+name: Auto-merge dependency updates
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependabot:
+    name: Enable auto-merge for Dependabot
+    if: >-
+      ${{
+        github.event_name == 'pull_request_target' &&
+        github.actor == 'dependabot[bot]' &&
+        github.event.pull_request.draft == false
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Approve Dependabot pull request
+        run: gh pr review "${PR_URL}" --approve --body "Automatische Freigabe für Dependabot nach erfolgreichen Pflichtchecks."
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+
+      - name: Enable auto-merge
+        run: gh pr merge "${PR_URL}" --auto --squash --delete-branch
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,13 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -40,6 +47,12 @@ jobs:
 
       - name: Set execute permissions for Gradle Wrapper
         run: chmod +x gradlew
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Build with Gradle
         run: ./gradlew clean build


### PR DESCRIPTION
### Motivation
- Reduce manual work by automatically approving and merging safe dependency updates from Dependabot. 
- Reduce CI churn and support merge queues by adding concurrency and merge-group triggers to the build workflow. 
- Make Gradle execution more robust by explicitly setting up Gradle and validating the wrapper before running builds. 
- Group dependency updates to reduce PR noise and better separate production vs development updates.

### Description
- Add `.github/workflows/auto-merge.yml` to approve non-draft Dependabot PRs and enable squash auto-merge using a GitHub App token and the `gh` CLI. 
- Extend `.github/workflows/build.yml` with `merge_group` and `workflow_dispatch` triggers, a `concurrency` block to cancel in-progress duplicate runs, `gradle/actions/setup-gradle` usage, and `gradle/actions/wrapper-validation` before running `./gradlew clean build`. 
- Update `.github/dependabot.yml` to introduce grouping rules for Gradle (`gradle-production-dependencies` and `gradle-development-dependencies`), GitHub Actions, and pip (`pip-dependencies`) to consolidate updates. 

### Testing
- Parsed all workflow files with `python ... yaml.safe_load(...)` and they loaded without errors. 
- Ran `./gradlew --version` to verify Gradle environment and it returned version information. 
- Executed `./gradlew test` and the test task completed with `BUILD SUCCESSFUL`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b763a4cf883258d28854730a4e4f9)