### PR TITLE
Group CodeQL action Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     open-pull-requests-limit: 500
     rebase-strategy: "auto"
 


### PR DESCRIPTION
### Motivation
- Group Dependabot updates for GitHub Actions so CodeQL action updates are consolidated into a single group matching `github/codeql-action*`.

### Description
- Add a `groups` entry under the `github-actions` section in `.github/dependabot.yml` defining a `codeql-action` group with pattern `github/codeql-action*`.

### Testing
- Loaded the modified YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "ok"'` which printed `ok` indicating the file parses successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50ef0aac188325a5b06edc85623ba2)